### PR TITLE
feat: block To attachment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41101,7 +41101,7 @@ const ACTION_INPUT_KEY_LIST = [...ACTION_REQUIRED_INPUT_KEY_LIST, ...ACTION_OPTI
  * 3001자 까지 대응이 되지만 특수한 케이스로 인하여 짤리는 경우를 대비하여 2800자로 정합니다.
  * **/
 const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800;
-const MAX_ATTACHMENT_BLOCK_COUNT = 100;
+const MAX_ATTACHMENT_BLOCK_COUNT = 50;
 const DEPLOY_ERROR_STATUS_LIST = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST = ['success'];
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -41101,6 +41101,7 @@ const ACTION_INPUT_KEY_LIST = [...ACTION_REQUIRED_INPUT_KEY_LIST, ...ACTION_OPTI
  * 3001자 까지 대응이 되지만 특수한 케이스로 인하여 짤리는 경우를 대비하여 2800자로 정합니다.
  * **/
 const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800;
+const MAX_ATTACHMENT_BLOCK_COUNT = 100;
 const DEPLOY_ERROR_STATUS_LIST = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST = ['success'];
 
@@ -43321,13 +43322,17 @@ const buildChunkListByText = (text, maxChunkLength = MAX_LENGTH_OF_SLACK_MESSAGE
 
 const buildAttachmentBlockList = (text) => {
     const builtChunkList = buildChunkListByText(text, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT);
-    return builtChunkList.map((text) => ({
+    const builtAttachmentBlockList = builtChunkList.map((chunk) => ({
         type: 'section',
         text: {
             type: 'mrkdwn',
-            text,
+            text: chunk,
         },
     }));
+    if (builtAttachmentBlockList.length <= MAX_ATTACHMENT_BLOCK_COUNT) {
+        return builtAttachmentBlockList;
+    }
+    return builtAttachmentBlockList.slice(0, MAX_ATTACHMENT_BLOCK_COUNT);
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -41098,13 +41098,9 @@ const ACTION_OPTIONAL_INPUT_KEY_LIST = [
 ];
 const ACTION_INPUT_KEY_LIST = [...ACTION_REQUIRED_INPUT_KEY_LIST, ...ACTION_OPTIONAL_INPUT_KEY_LIST];
 /**
- * Slack 메시지의 최대 길이입니다.
- * @see https://api.slack.com/methods/chat.postMessage
- * ----------------------------------------------------
- * 추후 truncating 처리를 한다면 제거 될 상수입니다.
- * @see https://api.slack.com/methods/chat.postMessage#truncating
+ * 3001자 까지 대응이 되지만 특수한 케이스로 인하여 짤리는 경우를 대비하여 2800자로 정합니다.
  * **/
-const MAX_LENGTH_OF_SLACK_MESSAGE = 4_000;
+const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800;
 const DEPLOY_ERROR_STATUS_LIST = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST = ['success'];
 
@@ -43294,11 +43290,53 @@ const getPullRequestNumber = async (token) => {
 };
 
 
+;// CONCATENATED MODULE: ./src/utils/buildChunkListByText.ts
+
+/**
+ * 청크 사이즈에 따라 텍스트를 나누는 유틸리티 함수입니다.
+ * 만약 청크 사이즈보다 작다면 그대로 반환합니다.
+ * 청크 사이즈보다 크다면, 청크 사이즈에 맞게 텍스트를 나누어 반환합니다.
+ * 청크 사이즈에 맞게 자른 뒤 재귀를 돌아 나누어 반환합니다.
+ * **/
+const buildChunkListByText = (text, maxChunkLength = MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT) => {
+    if (!text) {
+        return [];
+    }
+    const trimmedText = text.trim();
+    const isTextShorterThanMaxLength = trimmedText.length <= maxChunkLength;
+    if (isTextShorterThanMaxLength) {
+        return [trimmedText];
+    }
+    const lastNewlineBeforeChunkLimit = trimmedText.lastIndexOf('\n', maxChunkLength);
+    const chunkCutoffIndex = lastNewlineBeforeChunkLimit > 0 ? lastNewlineBeforeChunkLimit + 1 : maxChunkLength;
+    return [
+        trimmedText.slice(0, chunkCutoffIndex).trimEnd(),
+        ...buildChunkListByText(trimmedText.slice(chunkCutoffIndex), maxChunkLength),
+    ];
+};
+
+
+;// CONCATENATED MODULE: ./src/utils/slack/buildAttachmentBlockList.ts
+
+
+const buildAttachmentBlockList = (text) => {
+    const builtChunkList = buildChunkListByText(text, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT);
+    return builtChunkList.map((text) => ({
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text,
+        },
+    }));
+};
+
+
 ;// CONCATENATED MODULE: ./src/utils/slack/buildSlackMessage.ts
 
 
 const buildSlackMessage = ({ pullRequest: { title, url: pullRequestURL, number, body, owner, baseBranchName }, titleMessage, deployStatus = 'success', }) => {
-    const fields = [
+    const attachmentBlockList = [];
+    const fieldList = [
         {
             type: 'mrkdwn',
             text: `*merge 된 브랜치:* ${baseBranchName}`,
@@ -43308,7 +43346,7 @@ const buildSlackMessage = ({ pullRequest: { title, url: pullRequestURL, number, 
             text: `*PR 담당자:* ${(0,slack_messages.user)(owner)}`,
         },
     ];
-    const blocks = [
+    const blockList = [
         {
             type: 'header',
             text: {
@@ -43321,7 +43359,7 @@ const buildSlackMessage = ({ pullRequest: { title, url: pullRequestURL, number, 
         },
         {
             type: 'section',
-            fields,
+            fields: fieldList,
         },
         {
             type: 'section',
@@ -43333,16 +43371,19 @@ const buildSlackMessage = ({ pullRequest: { title, url: pullRequestURL, number, 
     ];
     // PR의 body가 존재하고 deployStatus 가 success 인 경우 body를 추가합니다.
     if (deployStatus === 'success' && body) {
-        blocks.push({ type: 'divider' }, {
-            type: 'section',
-            text: { type: 'mrkdwn', text: body.slice(0, MAX_LENGTH_OF_SLACK_MESSAGE) },
-        });
+        blockList.push({ type: 'divider' });
+        attachmentBlockList.push(...buildAttachmentBlockList(body));
     }
     return {
         username: 'ReleaseNotesBot',
         icon_emoji: ':dropshot:',
         text: titleMessage,
-        blocks: blocks,
+        blocks: blockList,
+        attachments: [
+            {
+                blocks: attachmentBlockList,
+            },
+        ],
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-notification-action",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -27,7 +27,7 @@ const ACTION_INPUT_KEY_LIST: ActionInputKey[] = [...ACTION_REQUIRED_INPUT_KEY_LI
  * **/
 const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800 as const;
 
-const MAX_ATTACHMENT_BLOCK_COUNT = 100 as const;
+const MAX_ATTACHMENT_BLOCK_COUNT = 50 as const;
 
 const DEPLOY_ERROR_STATUS_LIST: GithubDeploymentStatusState[] = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST: GithubDeploymentStatusState[] = ['success'];

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -25,7 +25,9 @@ const ACTION_INPUT_KEY_LIST: ActionInputKey[] = [...ACTION_REQUIRED_INPUT_KEY_LI
 /**
  * 3001자 까지 대응이 되지만 특수한 케이스로 인하여 짤리는 경우를 대비하여 2800자로 정합니다.
  * **/
-const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800;
+const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800 as const;
+
+const MAX_ATTACHMENT_BLOCK_COUNT = 100 as const;
 
 const DEPLOY_ERROR_STATUS_LIST: GithubDeploymentStatusState[] = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST: GithubDeploymentStatusState[] = ['success'];
@@ -37,4 +39,5 @@ export {
   ACTION_INPUT_KEY_LIST,
   ACTION_OPTIONAL_INPUT_KEY_LIST,
   MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT,
+  MAX_ATTACHMENT_BLOCK_COUNT,
 };

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -27,7 +27,17 @@ const ACTION_INPUT_KEY_LIST: ActionInputKey[] = [...ACTION_REQUIRED_INPUT_KEY_LI
  * **/
 const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800 as const;
 
+/**
+ * 슬랙 메시지 API > blocks 제한 갯수
+ * @see https://api.slack.com/reference/block-kit/blocks
+ */
 const MAX_ATTACHMENT_BLOCK_COUNT = 50 as const;
+
+/**
+ * 슬랙 메시지 API > attachments 제한 갯수
+ * @see https://api.slack.com/methods/chat.postMessage#errors > too_many_attachments
+ */
+const MAX_ATTACHMENT_COUNT = 100;
 
 const DEPLOY_ERROR_STATUS_LIST: GithubDeploymentStatusState[] = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST: GithubDeploymentStatusState[] = ['success'];
@@ -40,4 +50,5 @@ export {
   ACTION_OPTIONAL_INPUT_KEY_LIST,
   MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT,
   MAX_ATTACHMENT_BLOCK_COUNT,
+  MAX_ATTACHMENT_COUNT,
 };

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -23,22 +23,18 @@ const ACTION_OPTIONAL_INPUT_KEY_LIST: OptionalActionInputKey[] = [
 const ACTION_INPUT_KEY_LIST: ActionInputKey[] = [...ACTION_REQUIRED_INPUT_KEY_LIST, ...ACTION_OPTIONAL_INPUT_KEY_LIST];
 
 /**
- * Slack 메시지의 최대 길이입니다.
- * @see https://api.slack.com/methods/chat.postMessage
- * ----------------------------------------------------
- * 추후 truncating 처리를 한다면 제거 될 상수입니다.
- * @see https://api.slack.com/methods/chat.postMessage#truncating
+ * 3001자 까지 대응이 되지만 특수한 케이스로 인하여 짤리는 경우를 대비하여 2800자로 정합니다.
  * **/
-const MAX_LENGTH_OF_SLACK_MESSAGE = 4_000;
+const MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT = 2_800;
 
 const DEPLOY_ERROR_STATUS_LIST: GithubDeploymentStatusState[] = ['failure', 'error'];
 const DEPLOY_SUCCEED_STATUS_LIST: GithubDeploymentStatusState[] = ['success'];
 
 export {
   ACTION_REQUIRED_INPUT_KEY_LIST,
-  MAX_LENGTH_OF_SLACK_MESSAGE,
   DEPLOY_ERROR_STATUS_LIST,
   DEPLOY_SUCCEED_STATUS_LIST,
   ACTION_INPUT_KEY_LIST,
   ACTION_OPTIONAL_INPUT_KEY_LIST,
+  MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT,
 };

--- a/src/utils/buildChunkListByText.ts
+++ b/src/utils/buildChunkListByText.ts
@@ -1,0 +1,34 @@
+import { MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT } from '@/constants/common';
+
+/**
+ * 청크 사이즈에 따라 텍스트를 나누는 유틸리티 함수입니다.
+ * 만약 청크 사이즈보다 작다면 그대로 반환합니다.
+ * 청크 사이즈보다 크다면, 청크 사이즈에 맞게 텍스트를 나누어 반환합니다.
+ * 청크 사이즈에 맞게 자른 뒤 재귀를 돌아 나누어 반환합니다.
+ * **/
+const buildChunkListByText = (
+  text: string,
+  maxChunkLength: number = MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT
+): string[] => {
+  if (!text) {
+    return [];
+  }
+
+  const trimmedText = text.trim();
+
+  const isTextShorterThanMaxLength = trimmedText.length <= maxChunkLength;
+  if (isTextShorterThanMaxLength) {
+    return [trimmedText];
+  }
+
+  const lastNewlineBeforeChunkLimit = trimmedText.lastIndexOf('\n', maxChunkLength);
+
+  const chunkCutoffIndex = lastNewlineBeforeChunkLimit > 0 ? lastNewlineBeforeChunkLimit + 1 : maxChunkLength;
+
+  return [
+    trimmedText.slice(0, chunkCutoffIndex).trimEnd(),
+    ...buildChunkListByText(trimmedText.slice(chunkCutoffIndex), maxChunkLength),
+  ];
+};
+
+export { buildChunkListByText };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -14,4 +14,14 @@ const typedObjectEntries = <T extends object>(obj: T) => {
   return Object.entries(obj) as Entries<T>;
 };
 
-export { safeJsonParse, typedObjectEntries };
+const chunk = <T>(array: T[], size: number): T[][] => {
+  if (size <= 0) throw new Error('Size must be greater than 0');
+
+  if (array.length === 0) return [];
+
+  return Array.from({ length: Math.ceil(array.length / size) }, (_, index) =>
+    array.slice(index * size, (index + 1) * size)
+  );
+};
+
+export { safeJsonParse, typedObjectEntries, chunk };

--- a/src/utils/slack/buildAttachmentBlockList.ts
+++ b/src/utils/slack/buildAttachmentBlockList.ts
@@ -1,18 +1,24 @@
 import type { AnyBlock } from '@slack/types/dist/block-kit/blocks';
 
-import { MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT } from '@/constants/common';
+import { MAX_ATTACHMENT_BLOCK_COUNT, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT } from '@/constants/common';
 import { buildChunkListByText } from '@/utils/buildChunkListByText';
 
 const buildAttachmentBlockList = (text: string): AnyBlock[] => {
   const builtChunkList = buildChunkListByText(text, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT);
 
-  return builtChunkList.map((text) => ({
+  const builtAttachmentBlockList = builtChunkList.map((chunk) => ({
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text,
+      text: chunk,
     },
   }));
+
+  if (builtAttachmentBlockList.length <= MAX_ATTACHMENT_BLOCK_COUNT) {
+    return builtAttachmentBlockList;
+  }
+
+  return builtAttachmentBlockList.slice(0, MAX_ATTACHMENT_BLOCK_COUNT);
 };
 
 export { buildAttachmentBlockList };

--- a/src/utils/slack/buildAttachmentBlockList.ts
+++ b/src/utils/slack/buildAttachmentBlockList.ts
@@ -1,0 +1,18 @@
+import type { AnyBlock } from '@slack/types/dist/block-kit/blocks';
+
+import { MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT } from '@/constants/common';
+import { buildChunkListByText } from '@/utils/buildChunkListByText';
+
+const buildAttachmentBlockList = (text: string): AnyBlock[] => {
+  const builtChunkList = buildChunkListByText(text, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT);
+
+  return builtChunkList.map((text) => ({
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text,
+    },
+  }));
+};
+
+export { buildAttachmentBlockList };

--- a/src/utils/slack/buildAttachmentBlockList.ts
+++ b/src/utils/slack/buildAttachmentBlockList.ts
@@ -3,7 +3,12 @@ import type { AnyBlock } from '@slack/types/dist/block-kit/blocks';
 import { MAX_ATTACHMENT_BLOCK_COUNT, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT } from '@/constants/common';
 import { buildChunkListByText } from '@/utils/buildChunkListByText';
 
-const buildAttachmentBlockList = (text: string): AnyBlock[] => {
+const buildAttachmentBlockList = (
+  text: string
+): {
+  chunkedList: AnyBlock[];
+  omittedList: AnyBlock[];
+} => {
   const builtChunkList = buildChunkListByText(text, MAX_LENGTH_OF_SLACK_MESSAGE_FOR_ATTACHMENT);
 
   const builtAttachmentBlockList = builtChunkList.map((chunk) => ({
@@ -15,10 +20,16 @@ const buildAttachmentBlockList = (text: string): AnyBlock[] => {
   }));
 
   if (builtAttachmentBlockList.length <= MAX_ATTACHMENT_BLOCK_COUNT) {
-    return builtAttachmentBlockList;
+    return {
+      chunkedList: builtAttachmentBlockList,
+      omittedList: [],
+    };
   }
 
-  return builtAttachmentBlockList.slice(0, MAX_ATTACHMENT_BLOCK_COUNT);
+  return {
+    chunkedList: builtAttachmentBlockList.slice(0, MAX_ATTACHMENT_BLOCK_COUNT),
+    omittedList: builtAttachmentBlockList.slice(MAX_ATTACHMENT_BLOCK_COUNT, builtAttachmentBlockList.length),
+  };
 };
 
 export { buildAttachmentBlockList };


### PR DESCRIPTION
###### 기능 개발용 `downstream/feature-branch` to `upstream/dev`

## 리뷰 요약 정보

- 예상 리뷰 소요 시간: e.g., 5분, 30분
- 희망 리뷰 마감 기한: e.g., 이번주 수요일 오전

## 주요 변경점

-  슬랙 메시지 안정성을 위해 attachment 로 변경을 합니다. 
- 슬랙 메시지가 길 경우 줄바꿈 기준으로 재귀를 통해 이어붙입니다. 


## 검토자가 알아야 할 사항

- 우선 청크사이즈 대로 자르고 재귀를 돌아 처리를 했습니다. 더 좋은 방법이 있는지 같이 고민해봐주시면 감사드리겠습니다.
테스트 코드는 html 화 시켜 사내 슬랙에 공유 드리겠습니다.

