### PR TITLE
fix: 트리거 브랜치 정규화 수정

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43081,7 +43081,9 @@ const findMatchedProjectConfig = async ({ parsedProjectConfig, token, baseBranch
     });
     // parse 된 프로젝트 설정 중 현재 열린 pullRequest 에 baseBranchName 에 해당하는 프로젝트를 찾습니다.
     return parsedProjectConfig.find((projectConfig) => {
-        const isMatchedBranch = minimatch(baseBranchName, projectConfig.triggerBranch, {
+        // 단일 항목 브레이스 {xxx}를 xxx로 정규화
+        const normalizedTriggerBranch = projectConfig.triggerBranch.replace(/^\{([^,]+)}$/, '$1');
+        const isMatchedBranch = minimatch(baseBranchName, normalizedTriggerBranch, {
             nobrace: false,
         });
         const isMatchedFilePath = changedFileNameFromCommitHash.some((changedFileName) => {

--- a/src/utils/findMatchedProjectConfig.ts
+++ b/src/utils/findMatchedProjectConfig.ts
@@ -25,7 +25,10 @@ const findMatchedProjectConfig = async ({
 
   // parse 된 프로젝트 설정 중 현재 열린 pullRequest 에 baseBranchName 에 해당하는 프로젝트를 찾습니다.
   return parsedProjectConfig.find((projectConfig) => {
-    const isMatchedBranch = minimatch(baseBranchName, projectConfig.triggerBranch, {
+    // 단일 항목 브레이스 {xxx}를 xxx로 정규화
+    const normalizedTriggerBranch = projectConfig.triggerBranch.replace(/^\{([^,]+)}$/, '$1');
+    
+    const isMatchedBranch = minimatch(baseBranchName, normalizedTriggerBranch, {
       nobrace: false,
     });
 


### PR DESCRIPTION
###### hotfix 처리용 `downstream/hotfix` to `upstream/prod`

## 리뷰 요약 정보

- 예상 리뷰 소요 시간: e.g., 5분, 30분
- 희망 리뷰 마감 기한: e.g., 이번주 수요일 오전

## 주요 변경점

- 단일값을 {} 로 처리하는 경우 매칭을 못시키는 이슈 해결
   - 단일값일 경우에만 브레이스가 벗겨집니다. {test,test1} 같은 경우는 다중값이 유지됩니다.  



## 검토자가 알아야 할 사항

<img width="324" height="91" alt="image" src="https://github.com/user-attachments/assets/036afe00-3090-4c23-b9ae-9ce3354c431d" />

